### PR TITLE
Cleanup "Drivers" command

### DIFF
--- a/cogs/techinfo.py
+++ b/cogs/techinfo.py
@@ -4,11 +4,10 @@ import discord
 class techinfo(commands.Cog):
     @commands.hybrid_command(description="Get links to download various drivers")
     async def drivers(self, ctx):
-        embed = discord.Embed(title="Drivers", description="Links to downloads for various drivers", color=0x00a0a0)
-        embed.add_field(name="AMD Drivers:", value="https://amd.com/en/support", inline=False)
-        embed.add_field(name="nVidia Drivers:", value="https://nvidia.com/Download/index.aspx", inline=False)
+        embed = discord.Embed(title="Drivers", description="Download links for various drivers", color=0x00a0a0)
         embed.add_field(name="Intel Driver & Support Assistant:", value="https://dsadata.intel.com/installer", inline=False)
-        embed.add_field(name="Realtek Audio Drivers:", value="https://www.realtek.com/en/downloads", inline=False)
+        embed.add_field(name="AMD Drivers:", value="https://amd.com/en/support", inline=False)
+        embed.add_field(name="NVIDIA Drivers:", value="https://nvidia.com/Download/index.aspx", inline=False)
         await ctx.send(embed=embed)
 
     @commands.hybrid_command(name="driver-managers", aliases=["driverbooster", "drivereasy", "microsoft-drivers"], description="Explain why third party driver managers should not be used")

--- a/cogs/techinfo.py
+++ b/cogs/techinfo.py
@@ -5,7 +5,7 @@ class techinfo(commands.Cog):
     @commands.hybrid_command(description="Get links to download various drivers")
     async def drivers(self, ctx):
         embed = discord.Embed(title="Drivers", description="Download links for various drivers", color=0x00a0a0)
-        embed.add_field(name="Intel Driver & Support Assistant:", value="https://dsadata.intel.com/installer", inline=False)
+        embed.add_field(name="Intel Driver & Support Assistant:", value="https://www.intel.com/content/www/us/en/support/detect.html", inline=False)
         embed.add_field(name="AMD Drivers:", value="https://amd.com/en/support", inline=False)
         embed.add_field(name="NVIDIA Drivers:", value="https://nvidia.com/Download/index.aspx", inline=False)
         await ctx.send(embed=embed)


### PR DESCRIPTION
[fef3032](https://github.com/TechSupportCentral/TSCBot-py/pull/10/commits/fef303223be9cfa431fd8821c9fd91619b73be9c)
- Renamed "nVidia" to "NVIDIA" according to brand guidelines.   
https://www.nvidia.com/en-us/about-nvidia/legal-info/logo-brand-usage/

- Removed Realtek as audio drivers are hardware-specific, and should be obtained through the manufacturer's website if necessary. Installing the Realtek control panel can interfere with custom control panels (e.g. Nahimic, B&O Audio) installed by Windows Update.

[ca6cad5](https://github.com/TechSupportCentral/TSCBot-py/pull/10/commits/ca6cad51f0548eb4bcfe683ea442536ac1155f96)

- Changed "Intel Driver & Support Assistant", we should not link directly to executables.